### PR TITLE
Rimozione automatica Dice dai gruppi importanti e limitazione di /ludopatico

### DIFF
--- a/json/actions.json
+++ b/json/actions.json
@@ -120,7 +120,7 @@
   },
   "ludopatico": {
     "type": "luck",
-	"importantGroup": "Non puoi usare questo comando in quanto questo gruppo è ritentuo importante",
+    "importantGroup": "Non puoi usare questo comando in quanto questo gruppo è ritentuo importante",
     "description": "Tenta la fortuna"
   },
   "registrate": {

--- a/json/actions.json
+++ b/json/actions.json
@@ -120,7 +120,7 @@
   },
   "ludopatico": {
     "type": "luck",
-    "importantGroup": "Non puoi usare questo comando in quanto questo gruppo è ritentuo importante",
+    "importantGroup": "Questo gruppo è troppo importante per usare questo comando.",
     "description": "Tenta la fortuna"
   },
   "registrate": {

--- a/src/bot.js
+++ b/src/bot.js
@@ -8,53 +8,47 @@ const { data } = require("./jsons"),
  * @param {TelegramBot} bot The bot that should listen for the message.
  * @param {TelegramBot.Message} msg The message that triggered this action.
  */
-function onMessage(bot, msg)
-{
-	//Comando per eliminare l'emoji delle macchinette e altre che possono dar
-	//fastidio a causa di spam nei gruppi importanti
-	if (msg.dice)
-	{
-		bot.deleteMessage(msg.chat.id, msg.message_id);
-		return;
-	}
+function onMessage(bot, msg) {
+  //Comando per eliminare l'emoji delle macchinette e altre che possono dar
+  //fastidio a causa di spam nei gruppi importanti
+  if (msg.dice) {
+    bot.deleteMessage(msg.chat.id, msg.message_id);
+    return;
+  }
 
-	if (!msg.text) return; // no text
+  if (!msg.text) return; // no text
 
-	const text = msg.text.toString();
+  const text = msg.text.toString();
 
-	if (text[0] !== "/")
-	{
-		Object.entries(data.autoreply).forEach(([regexp, value]) => {
-		const indexOfAt = text.search(new RegExp(regexp, "i")); //case insensitive search
-		if (indexOfAt != -1) message(bot, msg, value);
-		});
-		return; // no command
-	}
+  if (text[0] !== "/") {
+    Object.entries(data.autoreply).forEach(([regexp, value]) => {
+      const indexOfAt = text.search(new RegExp(regexp, "i")); //case insensitive search
+      if (indexOfAt != -1) message(bot, msg, value);
+    });
+    return; // no command
+  }
 
-	// '/command@bot param0 ... paramN' -> 'command@bot'
-	let command = text.split(" ")[0].substring(1);
-	const indexOfAt = command.indexOf("@");
+  // '/command@bot param0 ... paramN' -> 'command@bot'
+  let command = text.split(" ")[0].substring(1);
+  const indexOfAt = command.indexOf("@");
 
-	if (indexOfAt != -1) {
-		if (command.substring(indexOfAt + 1) !== bot.username) return; // command issued to another bot
-		// 'command@bot' -> 'command'
-		command = command.substring(0, command.indexOf("@"));
-	}
-	try 
-	{
-		if (command in data.actions)
-			// action
-			act(bot, msg, data.actions[command]);
-		else if (command in data.memes)
-			// meme
-			message(bot, msg, data.memes[command]);
-			// unkown command
-		else act(bot, msg, data.actions["unknown"]);
-	}
-	catch (e)
-	{
-		console.error(e);
-	}
+  if (indexOfAt != -1) {
+    if (command.substring(indexOfAt + 1) !== bot.username) return; // command issued to another bot
+    // 'command@bot' -> 'command'
+    command = command.substring(0, command.indexOf("@"));
+  }
+  try {
+    if (command in data.actions)
+      // action
+      act(bot, msg, data.actions[command]);
+    else if (command in data.memes)
+      // meme
+      message(bot, msg, data.memes[command]);
+    // unkown command
+    else act(bot, msg, data.actions["unknown"]);
+  } catch (e) {
+    console.error(e);
+  }
 }
 
 /**

--- a/src/commands/basics.js
+++ b/src/commands/basics.js
@@ -40,16 +40,14 @@ function dice(bot, msg, emoji) {
 module.exports.dice = dice;
 
 /**
- * Controlla se ha senso limitare il comando /ludopatico
+ * Send a "dice" message if the chat is considered not important
  * @param {TelegramBot} bot The bot that should send the message.
  * @param {TelegramBot.Message} msg The message that triggered this action.
  * @param {string} importantGroup Text on the importance of the group
  */
 
 module.exports.considerLuck = function (bot, msg, importantGroup) {
-  var isImportant = false;
-
-  if (data.settings.generalGroups.includes(msg.chat.id)) isImportant = true;
+  const isImportant = data.settings.generalGroups.includes(msg.chat.id);
 
   if (!isImportant) dice(bot, msg);
   else message(bot, msg, importantGroup);

--- a/src/commands/basics.js
+++ b/src/commands/basics.js
@@ -46,19 +46,14 @@ module.exports.dice = dice;
  * @param {string} importantGroup Text on the importance of the group
  */
 
-module.exports.considerLuck = function (bot, msg, importantGroup)
-{
-	var isImportant = false;
-	const groupChatId = [-1563447632];
+module.exports.considerLuck = function (bot, msg, importantGroup) {
+  var isImportant = false;
 
-	if (groupChatId.includes(msg.chat.id))
-		isImportant = true;
+  if (data.settings.generalGroups.includes(msg.chat.id)) isImportant = true;
 
-	if (!isImportant)
-		dice(bot, msg);
-	else
-		message(bot, msg, importantGroup);
-}
+  if (!isImportant) dice(bot, msg);
+  else message(bot, msg, importantGroup);
+};
 
 /**
  * Sends a help message.

--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,12 @@
 const { data } = require("./jsons"),
   { tomorrowDate } = require("./util"),
-  { message, giveHelp, list, dice, considerLuck } = require("./commands/basics"),
+  {
+    message,
+    giveHelp,
+    list,
+    dice,
+    considerLuck
+  } = require("./commands/basics"),
   { lookingFor, notLookingFor } = require("./commands/looking-for"),
   { timetable, course } = require("./commands/uni"),
   { considerUpdating } = require("./commands/update"),
@@ -35,11 +41,7 @@ function act(bot, msg, action) {
       giveHelp(bot, msg);
       break;
     case "luck":
-	considerLuck(
-		bot,
-		msg,
-		action.importantGroup
-	);
+      considerLuck(bot, msg, action.importantGroup);
       //dice(bot, msg);
       break;
     case "lookingFor":


### PR DESCRIPTION
1) Nei gruppi ritenuti importanti le emoji classificate come "dice" vengono automaticamente rimosse dal bot senza eseguire nessuna altra azione.
2) Il comando /ludopatico è stato limitato per non essere eseguito nei così detti gruppi "importanti". Per ora è limitato esclusivamente solo sul gruppo del primo anno di informatica

Note:
Non sono riuscito a rispettare l'indentazione in quanto era troppo piccola. Spero che lo stile di codice da me adottato non comporti troppo danni alla repo.