### PR TITLE
Do not break on user not found

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go"]
+        language: "go"
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/utils/bot_utils.go
+++ b/utils/bot_utils.go
@@ -4,16 +4,28 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
 )
 
+func makeUnknownMember(chatConfigWithUser tgbotapi.ChatConfigWithUser) tgbotapi.ChatMember {
+	return tgbotapi.ChatMember{
+		User: &tgbotapi.User{
+			ID:        chatConfigWithUser.UserID,
+			FirstName: "???",
+			LastName:  "???",
+			UserName:  "???",
+		},
+	}
+}
+
 func GetChatMembers(bot *tgbotapi.BotAPI, chatID int64, memberIds []int) ([]tgbotapi.ChatMember, error) {
 	var members []tgbotapi.ChatMember
 
 	for _, id := range memberIds {
-		member, err := bot.GetChatMember(tgbotapi.ChatConfigWithUser{
+		chatConfigWithUser := tgbotapi.ChatConfigWithUser{
 			ChatID: chatID,
 			UserID: id,
-		})
+		}
+		member, err := bot.GetChatMember(chatConfigWithUser)
 		if err != nil {
-			return nil, err
+			member = makeUnknownMember(chatConfigWithUser)
 		}
 		members = append(members, member)
 	}


### PR DESCRIPTION
Fix a `/cercogruppo` nel caso in cui non si trovi uno degli utenti. Era uno scenario abbastanza comune in JavaScript.